### PR TITLE
feat(CORE): XP Balancing and Minor Fix

### DIFF
--- a/conf/Solocraft.conf.dist
+++ b/conf/Solocraft.conf.dist
@@ -21,7 +21,8 @@ Solocraft.Announce = 1
 
 
 ###################################################################################################
-#  Balancing - Groups (Overloading), Global Spellpower and Stats modifier, Global Class Balancing
+#  Balancing - Groups (Overloading), Global Spellpower and Stats modifier, Global Class Balancing, 
+#  and XP Gain Balancing
 ###################################################################################################
 
 # Enable Debuff of new party members who enter the dungeon to avoid overloading the dungeon? 
@@ -74,6 +75,26 @@ SoloCraft.ROGUE = 100
 SoloCraft.SHAMAN = 100
 SoloCraft.WARLOCK = 100
 SoloCraft.WARRIOR = 100
+
+
+# XP Gain 
+# This settings will Enable/Disable XP gained while in the current dungeon
+
+#Default: 1 (Enabled)
+#    	  0 (Disable)
+
+Solocraft.XP.Enabled = 1
+
+
+# XP Balancing (XP Gain must be Enabled)
+# This settings will decrease the XP gained based on the Difficulty setting of the dungeon
+# and how many players are in the group.
+
+#Default: 1 (Enabled)
+#    	  0 (Disable)
+
+Solocraft.XPBal.Enabled = 1
+
 
 ################################################################################################
 #Catch all Bucket - Difficulty Offset Defaults

--- a/src/Solocraft.cpp
+++ b/src/Solocraft.cpp
@@ -340,7 +340,7 @@ public:
 		}
     }
 
-	void OnGiveXP(Player* p, uint32& amount, Unit* /*victim*/) override
+	void OnGiveXP(Player* /*player*/, uint32& amount, Unit* /*victim*/) override
     {
         if (SolocraftXPBalEnabled) 
 		{

--- a/src/Solocraft.cpp
+++ b/src/Solocraft.cpp
@@ -318,7 +318,7 @@ public:
 
     SolocraftAnnounce() : PlayerScript("SolocraftAnnounce") {}
 
-    void OnLogin(Player* player)
+    void OnLogin(Player* player) override
     {
         // Announce Module
         if (SoloCraftEnable)
@@ -642,6 +642,7 @@ private:
 				{
 					//Database query to find difficulty for each group member that is currently in an instance
 					QueryResult result = CharacterDatabase.Query("SELECT `GUID`, `Difficulty`, `GroupSize` FROM `custom_solocraft_character_stats` WHERE GUID = {}", itr->guid.GetCounter());
+
 					if (result)
 					{
 						//Test for debuffs already give to other members - They cannot be used to determine the total offset because negative numbers will skew the total difficulty offset 
@@ -665,6 +666,7 @@ private:
 		{
 			float difficulty = (*result)[1].Get<float>();
 			int SpellPowerBonus = (*result)[3].Get<uint32>();
+
 			float StatsMultPct = (*result)[4].Get<float>();
 			SoloCraftXPMod = 1.0;
 

--- a/src/Solocraft.cpp
+++ b/src/Solocraft.cpp
@@ -329,7 +329,7 @@ public:
             }
         }
     }
-    void OnLogout(Player* player)
+    void OnLogout(Player* player) override
     {
 		//Database query to see if an entry is still there
 		QueryResult result = CharacterDatabase.Query("SELECT `GUID` FROM `custom_solocraft_character_stats` WHERE GUID = {}", player->GetGUID().GetCounter());


### PR DESCRIPTION
New Feature: XP Balancing:
Solocraft now has the ability to rein in experience gained to keep from over leveling your character by just going through one instance.  This rapid leveling is due to WOW giving your character all the shared XP from the instance that is supposed to be given to everyone in the group.  
The Feature has two options:  Disable/Enable XP Gain and Disable/Enable XP Balancing.   The balancing will take into account how many are in your group and balance it so your character only receives the amount you would get if you had the max amount of players in your group.    
  
Fix: Closes Issue #24
Was able to add giving a player's Pet max health upon entering the instance.  

TODO:
Pet Mana.  The normal methods of giving the max Mana to pets doesn't seem to work upon entering an instance.  Will still look for a working fix.