### PR TITLE
(bugfix) CalculateDifficulty should return a `float`, not an `int`

### DIFF
--- a/src/Solocraft.cpp
+++ b/src/Solocraft.cpp
@@ -372,7 +372,7 @@ private:
 	std::map<uint32, float> _unitDifficulty;
 
     // Set the instance difficulty
-    int CalculateDifficulty(Map* map, Player* /*player*/) {
+    float CalculateDifficulty(Map* map, Player* /*player*/) {
         //float difficulty = 0.0;//changed from 1.0
 
         if (map) {


### PR DESCRIPTION
Either I'm an idiot (which is a distinct possibility), or `CaclculateDifficulty` has been silently dropping anything after the decimal point for about four years.

I only noticed this issue when I tried setting difficulties less than `1.0` and I wasn't getting an in-game message from SoloCraft at all when transferring to a dungeon.

Tested on my up-to-date AzerothCore server. Working well with difficulties between `0.0` and `1.0`.