### PR TITLE
feat(SoloCraft): exclude map/instance from Solocraft scaling with conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ local.properties
 .loadpath
 .project
 .cproject
+
+#
+# Visual Studio Code
+#
+.vscode/

--- a/conf/Solocraft.conf.dist
+++ b/conf/Solocraft.conf.dist
@@ -439,3 +439,15 @@ Solocraft.QuarryOfTears.Level = 78
 Solocraft.HallsOfReflection.Level = 78
 # The Ruby Sanctum
 Solocraft.ChamberOfAspectsRed.Level = 80
+
+###################################################################################################
+#  Misc
+###################################################################################################
+
+# Map excluded
+# This settings excludes some maps from the Solocraft instance scaling
+
+# Example: 
+#   Solocraft.Instance.Excluded = "30,489,529,559,562,566,572,607,617,618,628"
+#   This example excludes scaling in PvP BG & Arena maps
+Solocraft.Instance.Excluded = ""

--- a/src/Solocraft.cpp
+++ b/src/Solocraft.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 bool SoloCraftEnable = 1;
 bool SoloCraftAnnounceModule = 1;

--- a/src/Solocraft.cpp
+++ b/src/Solocraft.cpp
@@ -12,6 +12,10 @@
 #include <math.h>
 #include <unordered_map>
 #include "ObjectGuid.h"
+#include "utils/Utils.h"
+#include <iostream>
+#include <vector>
+#include <string>
 
 bool SoloCraftEnable = 1;
 bool SoloCraftAnnounceModule = 1;
@@ -28,6 +32,7 @@ std::unordered_map<uint8, uint32> classes;
 std::unordered_map<uint32, uint32> dungeons;
 std::unordered_map<uint32, float> diff_Multiplier;
 std::unordered_map<uint32, float> diff_Multiplier_Heroics;
+std::vector<uint32_t> SolocraftInstanceExcluded;
 
 float D5 = 1.0;
 float D10 = 1.0;
@@ -305,6 +310,9 @@ public:
         //Unique Raids beyond the heroic and normal versions of themselves
         D649H10 = sConfigMgr->GetOption<float>("Solocraft.ArgentTournamentRaidH10", 10.0);  //Trial of the Crusader 10 Heroic
         D649H25 = sConfigMgr->GetOption<float>("Solocraft.ArgentTournamentRaidH25", 25.0);  //Trial of the Crusader 25 Heroic
+
+        //Get from conf excluded map for Solocraft scaling
+        LoadList(sConfigMgr->GetOption<std::string>("Solocraft.Instance.Excluded", ""), SolocraftInstanceExcluded);
     }
 };
 
@@ -361,6 +369,11 @@ class SolocraftPlayerInstanceHandler : public PlayerScript
 {
 public:
     SolocraftPlayerInstanceHandler() : PlayerScript("SolocraftPlayerInstanceHandler") {}
+    
+    bool IsInSolocraftInstanceExcludedList(uint32 id)
+    {
+        return find(SolocraftInstanceExcluded.begin(), SolocraftInstanceExcluded.end(), id) != SolocraftInstanceExcluded.end();
+    }
 
     void OnMapChanged(Player* player) override
     {
@@ -380,6 +393,11 @@ public:
     {
         if (map)
         {
+            if (IsInSolocraftInstanceExcludedList(map->GetId()))
+            {
+                return 0;
+            }
+
             if (map->Is25ManRaid())
             {
                 if (map->IsHeroic() && map->GetId() == 649)
@@ -536,8 +554,12 @@ public:
     // Apply the player buffs
     void ApplyBuffs(Player* player, Map* map, float difficulty, int dunLevel, int numInGroup, int classBalance)
     {
-        // Check whether to buff the player or check to debuff back to normal
-        if (difficulty != 0)
+        // Check whether to debuff back to normal or check to buff the player
+        if (difficulty == 0 || IsInSolocraftInstanceExcludedList(map->GetId()))
+        {
+            ClearBuffs(player); // Check to revert player back to normal - Moving this here fixed logout and login while in instance buff and debuff issues
+        }
+        else
         {
             std::ostringstream ss;
 
@@ -708,10 +730,6 @@ public:
                 ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), map->GetMapName(), dunLevel + SolocraftLevelDiff);
                 ClearBuffs(player); // Check to revert player back to normal
             }
-        }
-        else
-        {
-            ClearBuffs(player); // Check to revert player back to normal - Moving this here fixed logout and login while in instance buff and debuff issues
         }
     }
 

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -1,0 +1,16 @@
+#include "Utils.h"
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+std::vector<std::string> split(const std::string& str, char delimiter) {
+    std::vector<std::string> res;
+    if (str.empty()) return res;
+    std::string token;
+    std::istringstream tokenStream(str);
+    while (std::getline(tokenStream, token, delimiter)) {
+        res.push_back(token);
+    }
+    return res;
+}

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -1,0 +1,20 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <sstream>
+
+std::vector<std::string> split(const std::string& str, char delimiter);
+
+template <class T>
+void LoadList(const std::string& value, T& list) {
+    std::vector<std::string> ids = split(value, ',');
+    for (const std::string& id_str : ids) {
+        uint32_t id = static_cast<uint32_t>(std::atoi(id_str.c_str()));
+        list.push_back(id);
+    }
+}
+
+#endif

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -1,6 +1,7 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include <cstdint>
 #include <iostream>
 #include <vector>
 #include <string>


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Feature: Add the possibility to exclude somes map/instances from the scaling of Solocraft
- In my case I use it for a map like Alterac BG because i don't want player scaling in this

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- N/A

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Build on Debian 11 OK
- Github workflow OK on my branch
- In game tests (see below)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

Test with excluded maps:
1. Use Solocraft.Instance.Excluded = "30,489,529,559,562,566,572,607,617,618,628" in Solocraft.conf
2. Run server
3. Queue a 80 character for Alterac (map 30)
4. Enter and see peoples with normal stats
![image](https://github.com/user-attachments/assets/c35d3844-7198-41a9-a580-7e7670669df6)
![image](https://github.com/user-attachments/assets/c4a572e6-1d37-4d4b-8a78-69db6a378157)

Test without excluded maps:
1. Use Solocraft.Instance.Excluded = "" in Solocraft.conf
2. Run server
3. Queue a 80 character for Alterac (map 30)
4. Enter and see peoples with scaled stats
![image](https://github.com/user-attachments/assets/db774e7c-98aa-4dc4-9515-203a17359fe7)
![image](https://github.com/user-attachments/assets/053ded58-4cf0-4878-800e-1a1c07ed8035)

Sorry if my english is not in a very good state, not my native lang. 
And I'm not a very C++ dev so I can make a lot of mistake, forgive me.
