### PR TITLE
Fix BWL scaling in Solocraft.conf.dist

### DIFF
--- a/conf/Solocraft.conf.dist
+++ b/conf/Solocraft.conf.dist
@@ -138,7 +138,7 @@ Solocraft.Mauradon = 5.0
 Solocraft.OrgrimmarInstance = 5.0
 Solocraft.MoltenCore = 40.0
 Solocraft.DireMaul = 5.0
-Solocraft.BlackwingLair = 60.0
+Solocraft.BlackwingLair = 40.0
 # Ruins of Ahn'Qiraj
 Solocraft.AhnQiraj = 20.0
 Solocraft.AhnQirajTemple = 40.0
@@ -335,7 +335,7 @@ Solocraft.Mauradon.Level = 48
 Solocraft.OrgrimmarInstance.Level = 15
 Solocraft.MoltenCore.Level = 60
 Solocraft.DireMaul.Level = 48
-Solocraft.BlackwingLair.Level = 40
+Solocraft.BlackwingLair.Level = 60
 # Ruins of Ahn'Qiraj
 Solocraft.AhnQiraj.Level = 60
 Solocraft.AhnQirajTemple.Level = 60


### PR DESCRIPTION
BWL instance level and player count were swapped causing the module to incorrectly apply zero scaling to level 60 characters.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Change "Solocraft.BlackwingLair = 60.0" to "Solocraft.BlackwingLair = 40.0"
- Change "Solocraft.BlackwingLair.Level = 40" to "Solocraft.BlackwingLair.Level = 60"

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Once change was made, players appear to correctly scale in BWL at level 60. 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Test BWL pre-change. 
2. Test BWL post-change.
3.
