### PR TITLE
SpellPowerBonus now scales with gear bonus instead of level

### DIFF
--- a/conf/Solocraft.conf.dist
+++ b/conf/Solocraft.conf.dist
@@ -39,13 +39,13 @@ SoloCraft.Debuff.Enable = 1
 
 # Spellpower Bonus Multiplier
 # Spellcasters spellpower bonus multiplier to offset no spellpower received from stats
-# Formula: (player->level * multiplier) * ((classBalance / 100) * difficulty)
-# Example Level 24 Mage with default modifier and  a dungeon difficulty of 5 will receive a base 
+# Formula: (player->spellpower * multiplier) * ((classBalance / 100) * difficulty)
+# Example Mage with default modifier, 60 spel power bonus and a dungeon difficulty of 5 will receive a base 
 # Spellpower increase of 300.
 
-# Default:	2.5
+# Default:	1.0
 #			0.0 (Disable)
-SoloCraft.Spellpower.Mult = 2.5
+SoloCraft.Spellpower.Mult = 1.0
 
 
 # Stats Percentage Bonus Multiplier

--- a/src/Solocraft.cpp
+++ b/src/Solocraft.cpp
@@ -629,7 +629,7 @@ public:
                     // Debuffed characters do not get spellpower
                     if (difficulty > 0)
                     {
-                        SpellPowerBonus = static_cast<int>((player->GetLevel() * SoloCraftSpellMult) * difficulty);
+                        SpellPowerBonus = static_cast<int>((player->GetBaseSpellPowerBonus() * SoloCraftSpellMult) * difficulty);
                         player->ApplySpellPowerBonus(SpellPowerBonus, true);
                     }
                 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Make spell power bonus scale with gear instead of level


## Tests Performed:
- Tested in game


## How to Test the Changes:
1. Create a caster class (e.g. warlock)
2. Login into game
3. Enter dungeon
4. Check spellpower bonus
5. Change gear
6. Repeat steps steps 3-5 as much as needed
