### PR TITLE
Fixed spellpower scaling to max from single schools

### DIFF
--- a/conf/Solocraft.conf.dist
+++ b/conf/Solocraft.conf.dist
@@ -39,13 +39,13 @@ SoloCraft.Debuff.Enable = 1
 
 # Spellpower Bonus Multiplier
 # Spellcasters spellpower bonus multiplier to offset no spellpower received from stats
-# Formula: (player->level * multiplier) * ((classBalance / 100) * difficulty)
-# Example Level 24 Mage with default modifier and  a dungeon difficulty of 5 will receive a base 
+# Formula: (player->spellpower * multiplier) * ((classBalance / 100) * difficulty)
+# Example Mage with default modifier, 60 spel power bonus and a dungeon difficulty of 5 will receive a base 
 # Spellpower increase of 300.
 
-# Default:	2.5
+# Default:	1.0
 #			0.0 (Disable)
-SoloCraft.Spellpower.Mult = 2.5
+SoloCraft.Spellpower.Mult = 1.0
 
 
 # Stats Percentage Bonus Multiplier

--- a/src/Solocraft.cpp
+++ b/src/Solocraft.cpp
@@ -629,7 +629,7 @@ public:
                     // Debuffed characters do not get spellpower
                     if (difficulty > 0)
                     {
-                        SpellPowerBonus = static_cast<int>((player->GetLevel() * SoloCraftSpellMult) * difficulty);
+                        SpellPowerBonus = static_cast<int>((player->GetBaseSpellPowerBonus() * SoloCraftSpellMult) * difficulty);
                         player->ApplySpellPowerBonus(SpellPowerBonus, true);
                     }
                 }

--- a/src/Solocraft.cpp
+++ b/src/Solocraft.cpp
@@ -635,12 +635,10 @@ public:
 
                             int32 damage = player->SpellBaseDamageBonusDone(SpellSchoolMask(1 << school));
                             int32 healing = player->SpellBaseHealingBonusDone(SpellSchoolMask(1 << school));
-                            if (maxBonus < damage) {
-                                maxBonus = damage;
-                            }
-                            if (maxBonus < healing) {
-                                maxBonus = healing;
-                            }
+
+                            maxBonus = std::max(maxBonus, damage);
+                            maxBonus = std::max(maxBonus, healing);
+
                         }
                         SpellPowerBonus = static_cast<int>((maxBonus * SoloCraftSpellMult) * difficulty);
                         player->ApplySpellPowerBonus(SpellPowerBonus, true);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- SpellPower bonus now scales using max from the single schools

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes [No spellpower bonus at low levels](https://github.com/azerothcore/mod-solocraft/issues/59)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
- Tested with a lvl 80 warlock with different equipment sets, entering different instances


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a caster class character
2. Equip different sets of gear to your choice
3. Enter a instance max 9 levels below your character level
