### PR TITLE
fix handling of the percentage stat buff

### DIFF
--- a/data/sql/db-world/mod_solo_craft.sql
+++ b/data/sql/db-world/mod_solo_craft.sql
@@ -1,0 +1,1 @@
+INSERT INTO `spell_dbc` (`Id`,`Attributes`,`Effect_1`,`EffectAura_1`,`EffectMiscValue_1`,`Name_Lang_enUS`,`ProcChance`,`RangeIndex`,`EquippedItemClass`) VALUES (150000,448,6,137,-1,"Solocraft Mod Stats Percentage",101,1,-1);

--- a/data/sql/db-world/mod_solo_craft.sql
+++ b/data/sql/db-world/mod_solo_craft.sql
@@ -1,1 +1,2 @@
+DELETE FROM `spell_dbc` WHERE `Id` = 150000;
 INSERT INTO `spell_dbc` (`Id`,`Attributes`,`Effect_1`,`EffectAura_1`,`EffectMiscValue_1`,`Name_Lang_enUS`,`ProcChance`,`RangeIndex`,`EquippedItemClass`) VALUES (150000,448,6,137,-1,"Solocraft Mod Stats Percentage",101,1,-1);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Use an Aura to modify the percentage Stat buff instead of using the function.

This simplifies the usage as the amount does not have to be saved to remove it later and is not prone to rounding errors.
Can be merged without https://github.com/azerothcore/azerothcore-wotlk/pull/23346, but is required once that one is merge.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
